### PR TITLE
set the current date as default for the publish date field

### DIFF
--- a/src/Foundation/ScheduledPublish/code/sitecore/shell/Applications/Content Manager/Dialogs/Schedule Publish/SchedulePublishDialog.cs
+++ b/src/Foundation/ScheduledPublish/code/sitecore/shell/Applications/Content Manager/Dialogs/Schedule Publish/SchedulePublishDialog.cs
@@ -238,6 +238,7 @@ namespace ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.S
                 BuildExistingSchedules();
                 BuildPublishingTargets();
                 BuildLanguages();
+                PublishDateTimePicker.Value = DateUtil.ToIsoDate(DateTime.Now.AddMinutes(2));
 
                 ServerTime.Text = Constants.CURREN_TIME_ON_SERVER_TEXT + DateTime.Now.ToString(_culture);
                 SmartPublish.Checked = true;


### PR DESCRIPTION
Enables the dialog to set the publish date field to the current date for easy selection. 

![image](https://github.com/nehemiahj/SCScheduledPublishing/assets/8188106/52aa53c5-cd3e-43c0-91fd-3f2a12e2c9dd)
