### PR TITLE
warn content authors whether the item is in final workflow state or not if workflow is used

### DIFF
--- a/src/Foundation/ScheduledPublish/code/Utils/Constants.cs
+++ b/src/Foundation/ScheduledPublish/code/Utils/Constants.cs
@@ -18,6 +18,8 @@ namespace ScheduledPublish.Utils
         public const string CURREN_TIME_ON_SERVER_TEXT = "Current time on server: ";
         public const string NO_VALID_VERSION_TEXT = "no valid version";
         public const string NO_EXISTING_SCHEDULES_TEXT = "This item has not been scheduled for publishing yet.";
+        public const string ITEM_NOT_IN_FINAL_STATE_TEXT = "Warning! This item is not in the final workflow step.";
+        public const string ITEM_IN_FINAL_STATE_TEXT = "This item is in final workflow step.";
         public const string SCHEDULED_PUBLISH_NOTIFICATION = "This item has been scheduled for publish.";
         public const string SCHEDULED_PUBLISH_ICON = "People/16x16/clock_run.png";
         #endregion

--- a/src/Foundation/ScheduledPublish/code/sitecore/shell/Applications/Content Manager/Dialogs/Schedule Publish/Schedule Publish.xml
+++ b/src/Foundation/ScheduledPublish/code/sitecore/shell/Applications/Content Manager/Dialogs/Schedule Publish/Schedule Publish.xml
@@ -4,6 +4,9 @@
     <FormDialog ID="ScheduleFormDialog" Icon="Network/32x32/earth_time.png" Header="Scheduled Publish" Text="Configure when the current item is scheduled for publish.">
       <CodeBeside Type="ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.Schedule_Publish.SchedulePublishDialog, ScheduledPublish"/>
       <GridPanel Width="100%" Height="100%" Fixed="true">
+        <Groupbox Header="Workflow State" ID="GrpWorkflowState" Margin="0px 0px 16px 0px">
+		  <Literal ID="LtrItemWorkflowState" Width="100%" />          
+        </Groupbox>
         <Groupbox Header="Existing Schedules" Margin="0px 0px 16px 0px">
           <Border ID="ExistingSchedules" Width="100%" />
         </Groupbox>

--- a/src/Foundation/ScheduledPublish/code/sitecore/shell/Applications/Content Manager/Dialogs/Schedule Publish/SchedulePublishDialog.cs
+++ b/src/Foundation/ScheduledPublish/code/sitecore/shell/Applications/Content Manager/Dialogs/Schedule Publish/SchedulePublishDialog.cs
@@ -30,6 +30,7 @@ using Constants = ScheduledPublish.Utils.Constants;
 using Control = Sitecore.Web.UI.HtmlControls.Control;
 using ItemList = Sitecore.Collections.ItemList;
 using Action = Sitecore.Web.UI.HtmlControls.Action;
+using Sitecore.Workflows;
 
 namespace ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.Schedule_Publish
 {
@@ -41,7 +42,9 @@ namespace ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.S
         protected Groupbox ScheduleSettings;
         protected Groupbox ScheduleLanguages;
         protected Groupbox ScheduleTargets;
+        protected Groupbox GrpWorkflowState;
         protected Border ExistingSchedules;
+        protected Literal LtrItemWorkflowState;
         protected GridPanel GridRecurrence;
         protected Border Languages;
         protected Border PublishModePanel;
@@ -238,6 +241,7 @@ namespace ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.S
                 BuildExistingSchedules();
                 BuildPublishingTargets();
                 BuildLanguages();
+                BuildItemWorkflowStateStatus();
                 PublishDateTimePicker.Value = DateUtil.ToIsoDate(DateTime.Now.AddMinutes(2));
 
                 ServerTime.Text = Constants.CURREN_TIME_ON_SERVER_TEXT + DateTime.Now.ToString(_culture);
@@ -445,6 +449,36 @@ namespace ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.S
             ExistingSchedules.InnerHtml = string.IsNullOrWhiteSpace(schedulesHtml)
                 ? Constants.NO_EXISTING_SCHEDULES_TEXT
                 : schedulesHtml;
+        }
+
+        /// <summary>
+        /// Displays a status of the item workflow state. If not in final state, there will be warning. 
+        /// </summary>
+        private void BuildItemWorkflowStateStatus()
+        {
+            WorkflowState currentState;
+            if (InnerItem != null)
+            {
+                IWorkflow itemWorkflow = _database.WorkflowProvider.GetWorkflow(InnerItem);
+                if (itemWorkflow != null)
+                {
+                    currentState = itemWorkflow.GetState(InnerItem);
+                    if (currentState != null && currentState.FinalState)
+                    {
+                        LtrItemWorkflowState.Text = Constants.ITEM_IN_FINAL_STATE_TEXT;
+                        LtrItemWorkflowState.Style.Add("color", "green");
+                    }
+                    else
+                    {
+                        LtrItemWorkflowState.Text = Constants.ITEM_NOT_IN_FINAL_STATE_TEXT;
+                        LtrItemWorkflowState.Style.Add("color", "red");
+                    }
+                }
+                else
+                {
+                    GrpWorkflowState.Visible = false;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The final workflow state is an important part of Sitecore's workflow system. It helps ensure that content items are published in a controlled manner and are not accidentally changed after they are published.

If an item scheduled for publishing is not in the final workflow state, the publish job will not publish the item or will publish the last approved item version. To remind the content authors, a warning has been added to the dialog that shows whether the item is in the final state. If the item does not have a workflow, this section is hidden. 

![image](https://github.com/nehemiahj/SCScheduledPublishing/assets/8188106/fc545359-856e-45e2-ae33-62fdd89e1956)

![image](https://github.com/nehemiahj/SCScheduledPublishing/assets/8188106/cfc3888d-c7a7-4b08-8b3a-39953b586f46)



