### PR TITLE
Allow ToggleRecurrence to be called through reflection

### DIFF
--- a/src/Foundation/ScheduledPublish/code/App_Config/Include/ZZ_ScheduledPublish/ZZ_ScheduledPublishControl.config
+++ b/src/Foundation/ScheduledPublish/code/App_Config/Include/ZZ_ScheduledPublish/ZZ_ScheduledPublishControl.config
@@ -20,5 +20,10 @@
     <settings>
       <setting name="RolesField.DomainParameterName" value="domain" />
     </settings>
+    <reflection>
+        <allowedMethods>
+            <descriptor type="ScheduledPublish.sitecore.shell.Applications.Content_Manager.Dialogs.Schedule_Publish.SchedulePublishDialog" methodName="ToggleRecurrence" assemblyName="ScheduledPublish" hint="ScheduledPublish.ToggleRecurrence" />
+        </allowedMethods>
+    </reflection>
   </sitecore>
 </configuration>


### PR DESCRIPTION
Sitecore has restricted calls allowed through reflection to resolve a few high risk vulnerabilities. This restriction actually breaks the recurrence button because it needs to be added to the allowed list.